### PR TITLE
Filter messages on the "user" field

### DIFF
--- a/packit_service_fedmsg/consumer.py
+++ b/packit_service_fedmsg/consumer.py
@@ -77,8 +77,8 @@ class Consumerino:
         :param message: Message from Fedora message bus
         :return: None
         """
-        if message.body.get("owner") != "packit":
-            logger.info("Not handled by packit!")
+        if message.body.get("user") != "packit":
+            logger.info("Not built by packit!")
             return
 
         if message.topic not in INTERESTED_TOPICS:


### PR DESCRIPTION
The current code checks the "owner" field when deciding whether to drop
a message as the build was not started by Packit.

This is true in most of the cases, except when Packit Service builds in
a Copr repo owned by someone else. In these cases the check on "owner"
results in dropping that message and having to wait for the babysit task
to notice that the build started or ended.

To fix this, instead of checking who's the owner of the project where
the build belongs, check who started the build, by looking at the "user"
field.

See the copr-messaging schema:

https://pagure.io/copr/copr/blob/master/f/messaging/copr_messaging/private/schema_old.py#_82

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>