### PR TITLE
Remove INTERESTED_TOPICS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
       - id: black
         language_version: python3.6
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.0.5
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -23,14 +23,14 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.2
     hooks:
       - id: flake8
         args:
           - --max-line-length=100
           - --per-file-ignores=files/packit.wsgi:F401,E402
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.761
+    rev: v0.770
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]

--- a/packit_service_fedmsg/consumer.py
+++ b/packit_service_fedmsg/consumer.py
@@ -30,11 +30,6 @@ from fedora_messaging.message import Message
 config.conf.setup_logging()
 logger = getLogger(__name__)
 
-INTERESTED_TOPICS = {
-    "org.fedoraproject.prod.copr.build.end",
-    "org.fedoraproject.prod.copr.build.start",
-}
-
 
 class Consumerino:
     """
@@ -80,10 +75,6 @@ class Consumerino:
         """
         if message.body.get("user") != "packit":
             logger.info("Not built by packit!")
-            return
-
-        if message.topic not in INTERESTED_TOPICS:
-            logger.debug("Not interested topic")
             return
 
         logger.info(message.body.get("what"))


### PR DESCRIPTION
It was added (98fea04) back in the days when we were seeing
some infrastructure problems related to `copr` & `fedora-messaging`
and this was one of the workarounds.

I think it can be removed now because
we haven't seen any problems for quite some time.